### PR TITLE
estebanreyl/buildLogs (Rebased)

### DIFF
--- a/commands/acr-build.ts
+++ b/commands/acr-build.ts
@@ -1,0 +1,114 @@
+import { ContainerRegistryManagementClient } from 'azure-arm-containerregistry';
+import { QuickBuildRequest } from "azure-arm-containerregistry/lib/models";
+import { Registry } from 'azure-arm-containerregistry/lib/models';
+import { ResourceManagementClient } from 'azure-arm-resource';
+import { BlobService, createBlobServiceWithSas } from "azure-storage";
+import * as fs from 'fs';
+import * as os from 'os';
+import * as tar from 'tar';
+import * as url from 'url';
+import * as vscode from "vscode";
+import { getBlobInfo } from "../utils/Azure/acrTools";
+import { AzureUtilityManager } from "../utils/azureUtilityManager";
+import { quickPickACRRegistry, quickPickResourceGroup, quickPickSubscription } from './utils/quick-pick-azure';
+const idPrecision = 6;
+let status = vscode.window.createOutputChannel('status');
+
+// Prompts user to select a subscription, resource group, then registry from drop down. If there are multiple folders in the workspace, the source folder must also be selected.
+// The user is then asked to name & tag the image. A build is queued for the image in the selected registry.
+// Selected source code must contain a path to the desired dockerfile.
+export async function queueBuild(dockerFileUri?: vscode.Uri): Promise<void> {
+    status.show();
+    status.appendLine("Obtaining Subscription and Client");
+    let subscription = await quickPickSubscription();
+    let client = AzureUtilityManager.getInstance().getContainerRegistryManagementClient(subscription);
+    const resourceGroupClient = new ResourceManagementClient(AzureUtilityManager.getInstance().getCredentialByTenantId(subscription.tenantId), subscription.subscriptionId);
+
+    let resourceGroup = await quickPickResourceGroup(false, subscription);
+    let resourceGroupName = resourceGroup.name;
+
+    let registry: Registry = await quickPickACRRegistry(false);
+    let registryName = registry.name;
+
+    let folder: vscode.WorkspaceFolder;
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
+        folder = vscode.workspace.workspaceFolders[0];
+    } else {
+        folder = await (<any>vscode).window.showWorkspaceFolderPick();
+    }
+    let sourceLocation: string = folder.uri.path;
+
+    let relativeDockerPath = 'Dockerfile';
+    if (dockerFileUri.path.indexOf(sourceLocation) !== 0) {
+        //Currently, there is no support for selecting source location folders that don't contain a path to the triggered dockerfile.
+        throw new Error("Source code path must be a parent of the Dockerfile path");
+    } else {
+        relativeDockerPath = dockerFileUri.path.toString().substring(sourceLocation.length);
+    }
+
+    // Prompting for name so the image can then be pushed to a repository.
+    const opt: vscode.InputBoxOptions = {
+        prompt: 'Image name and tag in format  <name>:<tag>',
+    };
+    const name: string = await vscode.window.showInputBox(opt);
+
+    let tarFilePath = getTempSourceArchivePath();
+
+    status.appendLine("Uploading Source Code to " + tarFilePath);
+    sourceLocation = await uploadSourceCode(client, registryName, resourceGroupName, sourceLocation, tarFilePath);
+
+    let osType = os.type()
+    if (osType === 'Windows_NT') {
+        osType = 'Windows'
+    }
+
+    status.appendLine("Setting up Build Request");
+    let buildRequest: QuickBuildRequest = {
+        'type': 'QuickBuild',
+        'imageNames': [name],
+        'isPushEnabled': true,
+        'sourceLocation': sourceLocation,
+        'platform': { 'osType': osType },
+        'dockerFilePath': relativeDockerPath
+    };
+    status.appendLine("Queueing Build");
+    await client.registries.queueBuild(resourceGroupName, registryName, buildRequest);
+    status.appendLine('Success');
+}
+
+async function uploadSourceCode(client: ContainerRegistryManagementClient, registryName: string, resourceGroupName: string, sourceLocation: string, tarFilePath: string): Promise<string> {
+    status.appendLine("   Sending source code to temp file");
+    tar.c(
+        {
+            gzip: true
+        },
+        [sourceLocation]
+    ).pipe(fs.createWriteStream(tarFilePath));
+
+    status.appendLine("   Getting Build Source Upload Url ");
+    let sourceUploadLocation = await client.registries.getBuildSourceUploadUrl(resourceGroupName, registryName);
+    let upload_url = sourceUploadLocation.uploadUrl;
+    let relative_path = sourceUploadLocation.relativePath;
+
+    status.appendLine("   Getting blob info from Upload Url ");
+    // Right now, accountName and endpointSuffix are unused, but will be used for streaming logs later.
+    let { accountName, endpointSuffix, containerName, blobName, sasToken, host } = getBlobInfo(upload_url);
+
+    status.appendLine("   Creating Blob Service ");
+    let blob: BlobService = createBlobServiceWithSas(host, sasToken);
+
+    status.appendLine("   Creating Block Blob ");
+
+    blob.createBlockBlobFromLocalFile(containerName, blobName, tarFilePath, (): void => { });
+
+    status.appendLine("   Success ");
+    return relative_path;
+}
+
+function getTempSourceArchivePath(): string {
+    /* tslint:disable-next-line:insecure-random */
+    let id = Math.floor(Math.random() * Math.pow(10, idPrecision));
+    status.appendLine("Setting up temp file with 'sourceArchive" + id + ".tar.gz' ");
+    let tarFilePath = url.resolve(os.tmpdir(), `sourceArchive${id}.tar.gz`);
+    return tarFilePath;
+}

--- a/commands/azureCommands/acr-build-logs-utils/logProvider.ts
+++ b/commands/azureCommands/acr-build-logs-utils/logProvider.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+
+export class LogContentProvider implements vscode.TextDocumentContentProvider {
+    public static scheme: string = 'purejs';
+    private onDidChangeEvent: vscode.EventEmitter<vscode.Uri> = new vscode.EventEmitter<vscode.Uri>();
+
+    constructor() { }
+
+    public provideTextDocumentContent(uri: vscode.Uri): string {
+        return this.stylehtml(this.decodeBase64(JSON.parse(uri.query).log));
+    }
+
+    get onDidChange(): vscode.Event<vscode.Uri> {
+        return this.onDidChangeEvent.event;
+    }
+
+    public update(uri: vscode.Uri, message: string): void {
+        this.onDidChangeEvent.fire(uri);
+    }
+
+    private decodeBase64(str: string): string {
+        return Buffer.from(str, 'base64').toString('ascii');
+    }
+
+    private stylehtml(log: string): string {
+        let processedLog: string = '';
+        const lines: string[] = log.split(`\n`);
+        if (lines.length === 0) { return 'This Log appears to be empty'; }
+        lines[0] = lines[0].trim();
+
+        for (let line of lines) {
+            if (line.toLowerCase().indexOf('error') !== -1 || line.toLowerCase().indexOf('fail') !== -1) {
+                processedLog += `<span class = 'r'>${line}\n </span>`
+            } else if (line.toLowerCase().indexOf('success') !== -1 || line.toLowerCase().indexOf('succeeded') !== -1 || line.toLowerCase().indexOf('complete') !== -1 ||
+                line.toLowerCase().indexOf('0 warning(s)') !== -1 || line.toLowerCase().indexOf('0 error(s)') !== -1) {
+                processedLog += `<span class = 'g'>${line}\n </span>`
+            } else {
+                processedLog += `${line}\n`
+            }
+        }
+        return `
+        <doctype = <!DOCTYPE html>
+        <html>
+            <head>
+                <meta charset="utf-8" />
+                <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                <title>Page Title</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <style>
+                    body{
+                        font-size: var(--vscode-editor-font-size);
+                        font-family: var(--vscode-editor-font-family);
+                    }
+                    pre{
+                        font-size: var(--vscode-editor-font-size);
+                        font-family: var(--vscode-editor-font-family);
+                    }
+                    .r{
+                        color:lightcoral;
+                    }
+                    .g{
+                        color:lightgreen;
+                    }
+
+                </style>
+            </head>
+
+            <body>
+                <pre>${processedLog}</pre>
+            </body>
+        </html>`
+    }
+}

--- a/commands/azureCommands/acr-build-logs-utils/logProvider.ts
+++ b/commands/azureCommands/acr-build-logs-utils/logProvider.ts
@@ -51,9 +51,9 @@ export class LogContentProvider implements vscode.TextDocumentContentProvider {
                         font-size: var(--vscode-editor-font-size);
                         font-family: var(--vscode-editor-font-family);
                     }
-                    pre{
+                    #force{
                         font-size: var(--vscode-editor-font-size);
-                        font-family: var(--vscode-editor-font-family);
+                        font-family: monospace;
                         font-size: var(--font-size);
                         font-weight: var(--font-weight);
                     }
@@ -68,7 +68,7 @@ export class LogContentProvider implements vscode.TextDocumentContentProvider {
             </head>
 
             <body>
-                <pre>${processedLog}</pre>
+                <pre><span id="force">${processedLog}</span></pre>
             </body>
         </html>`
     }

--- a/commands/azureCommands/acr-build-logs-utils/logProvider.ts
+++ b/commands/azureCommands/acr-build-logs-utils/logProvider.ts
@@ -54,12 +54,14 @@ export class LogContentProvider implements vscode.TextDocumentContentProvider {
                     pre{
                         font-size: var(--vscode-editor-font-size);
                         font-family: var(--vscode-editor-font-family);
+                        font-size: var(--font-size);
+                        font-weight: var(--font-weight);
                     }
                     .r{
-                        color:lightcoral;
+                        color:var(--vscode-terminal-ansiBrightRed);
                     }
                     .g{
-                        color:lightgreen;
+                        color:var(--vscode-terminal-ansiBrightGreen);
                     }
 
                 </style>

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -42,13 +42,13 @@ function sortTable(n, dir = "asc", holdDir = false) {
     currentN = n;
     let table, rows, switching, i, x, y, shouldSwitch, switchcount = 0;
     let cmpFunc = acquireCompareFunction(n);
-    table = document.getElementById("core");
+    table = document.getElementById("coreParent");
     switching = true;
     //Set the sorting direction to ascending:
 
     while (switching) {
         switching = false;
-        rows = table.getElementsByClassName("holder");
+        rows = table.querySelectorAll(".accordion");
         for (i = 0; i < rows.length - 1; i++) {
             shouldSwitch = false;
             x = rows[i].getElementsByTagName("TD")[n];
@@ -81,16 +81,18 @@ function sortTable(n, dir = "asc", holdDir = false) {
 
 function acquireCompareFunction(n) {
     switch (n) {
-        case 0: //Name
-        case 1: //Build Task
+        case 0:
+            return;
+        case 1: //Name
+        case 2: //Build Task
             return (x, y) => {
                 return x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()
             }
-        case 2: //Status
+        case 3: //Status
             return (x, y) => {
                 return status[x.innerHTML] > status[y.innerHTML];;
             }
-        case 3: //Created time
+        case 4: //Created time
             return (x, y) => {
                 if (x.innerHTML === '') return true;
                 if (y.innerHTML === '') return false;
@@ -98,13 +100,13 @@ function acquireCompareFunction(n) {
                 let dateY = new Date(y.innerHTML);
                 return dateX > dateY;
             }
-        case 4: //Elapsed time
+        case 5: //Elapsed time
             return (x, y) => {
                 if (x.innerHTML === '') return true;
                 if (y.innerHTML === '') return false;
-                return (+x.innerHTML.substring(0, x.innerHTML.length)) > (+y.innerHTML.substring(0, x.innerHTML.length));
+                return (+x.innerHTML.substring(0, x.innerHTML.length - 1)) > (+y.innerHTML.substring(0, x.innerHTML.length - 1));
             }
-        case 5: //OS Type
+        case 6: //OS Type
             return (x, y) => {
                 return x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()
             }
@@ -157,7 +159,7 @@ function setTableSorter() {
     let items = document.getElementsByTagName('TH');
     for (let i = 0; i < items.length; i++) {
         items[i].addEventListener('click', () => {
-            sortTable(i)
+            sortTable(i);
         });
     }
 }

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -14,8 +14,8 @@ var modalObject = {
 };
 
 var triangles = {
-    'down': ' △',
-    'up': ' ▽'
+    'down': ' ▽',
+    'up': ' △'
 }
 
 // Main

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -139,10 +139,12 @@ function setSingleAccordion(item) {
         this.querySelector('.arrow').classList.toggle('activeArrow');
         var panel = this.nextElementSibling;
         if (panel.style.maxHeight) {
+            panel.style.display = 'none';
             panel.style.maxHeight = null;
         } else {
-            let paddingTop = +panel.querySelector('.paddingDiv').style.paddingTop.split('px')[0];
-            let paddingBottom = +panel.querySelector('.paddingDiv').style.paddingBottom.split('px')[0];
+            panel.style.display = 'table-row';
+            let paddingTop = +panel.style.paddingTop.split('px')[0];
+            let paddingBottom = +panel.style.paddingBottom.split('px')[0];
             panel.style.maxHeight = (panel.scrollHeight + paddingTop + paddingBottom) + 'px';
         }
     });

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -18,6 +18,7 @@ let content = document.querySelector('#core');
 const vscode = acquireVsCodeApi();
 setLoadMoreListener();
 setTableSorter();
+window.addEventListener("resize", manageWidth);
 
 modalObject.overlay.addEventListener('click', (event) => {
     if (event.target === modalObject.overlay) {
@@ -129,6 +130,8 @@ window.addEventListener('message', event => {
 
     } else if (message.type === 'endContinued') {
         sortTable(currentN, currentDir, true);
+    } else if (message.type === 'end') {
+        manageWidth();
     }
 
 });
@@ -188,3 +191,16 @@ function setDigestListener(digestClickables) {
         });
     }
 }
+
+function manageWidth() {
+    let headerCells = document.querySelectorAll("#headerTable th");
+    let topRow = document.querySelector("#core tr");
+    let topRowCells = topRow.querySelectorAll("td");
+    console.log(topRowCells);
+    for (let i = 0; i < topRowCells.length; i++) {
+        let width = parseInt(getComputedStyle(topRowCells[i]).width);
+        console.log(width);
+        headerCells[i].style.width = width + "px";
+    }
+}
+

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -1,0 +1,183 @@
+// Global Variables
+const status = {
+    'Succeeded': 4,
+    'Queued': 3,
+    'Error': 2,
+    'Failed': 1
+}
+
+var currentN = 4;
+var currentDir = "asc"
+var modalObject = {
+    modal: document.querySelector('.modal'),
+    overlay: document.querySelector('.overlay')
+};
+
+// Main
+let content = document.querySelector('#core');
+const vscode = acquireVsCodeApi();
+setLoadMoreListener();
+setTableSorter();
+
+modalObject.overlay.addEventListener('click', (event) => {
+    if (event.target === modalObject.overlay) {
+        modalObject.overlay.style.display = 'none';
+        modalObject.modal.style.display = 'none';
+    }
+});
+
+const copy = modalObject.modal.querySelector('.copyBtn');
+copy.addEventListener('click', () => {
+    modalObject.modal.querySelector('#digestVisualizer').select();
+    document.execCommand("copy");
+});
+
+/* Sorting
+ * PR note, while this does not use a particularly quick algorithm
+ * it allows a low stuttering experience that allowed rapid testing.
+ * I will improve it soon.*/
+function sortTable(n, dir = "asc", holdDir = false) {
+    currentDir = dir;
+    currentN = n;
+    let table, rows, switching, i, x, y, shouldSwitch, switchcount = 0;
+    let cmpFunc = acquireCompareFunction(n);
+    table = document.getElementById("core");
+    switching = true;
+    //Set the sorting direction to ascending:
+
+    while (switching) {
+        switching = false;
+        rows = table.getElementsByClassName("holder");
+        for (i = 0; i < rows.length - 1; i++) {
+            shouldSwitch = false;
+            x = rows[i].getElementsByTagName("TD")[n];
+            y = rows[i + 1].getElementsByTagName("TD")[n];
+            if (dir == "asc") {
+                if (cmpFunc(x, y)) {
+                    shouldSwitch = true;
+                    break;
+                }
+            } else if (dir == "desc") {
+                if (cmpFunc(y, x)) {
+                    shouldSwitch = true;
+                    break;
+                }
+            }
+        }
+        if (shouldSwitch) {
+            rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+            switching = true;
+            switchcount++;
+        } else {
+            /*If no switching has been done AND the direction is "asc", set the direction to "desc" and run the while loop again.*/
+            if (switchcount == 0 && dir == "asc" && !holdDir) {
+                dir = "desc";
+                switching = true;
+            }
+        }
+    }
+}
+
+function acquireCompareFunction(n) {
+    switch (n) {
+        case 0: //Name
+        case 1: //Build Task
+            return (x, y) => {
+                return x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()
+            }
+        case 2: //Status
+            return (x, y) => {
+                return status[x.innerHTML] > status[y.innerHTML];;
+            }
+        case 3: //Start time
+        case 4: // Finish time
+            return (x, y) => {
+                if (x.innerHTML === '?') return true;
+                if (y.innerHTML === '?') return false;
+                let dateX = new Date(x.innerHTML);
+                let dateY = new Date(y.innerHTML);
+                return dateX > dateY;
+            }
+        case 5: //OS Type
+            return (x, y) => {
+                return x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()
+            }
+        default:
+            throw 'Could not acquire Compare function, invalid n';
+    }
+}
+
+// Event Listener Setup
+window.addEventListener('message', event => {
+    const message = event.data; // The JSON data our extension sent
+    if (message.type === 'populate') {
+        content.insertAdjacentHTML('beforeend', message.logComponent);
+
+        let item = content.querySelector(`#btn${message.id}`);
+        setSingleAccordion(item);
+
+        const logButton = content.querySelector(`#log${message.id}`);
+        setLogBtnListener(logButton);
+
+        const digestClickables = item.nextElementSibling.querySelectorAll('.copy');
+        setDigestListener(digestClickables);
+
+    } else if (message.type === 'endContinued') {
+        sortTable(currentN, currentDir, true);
+    }
+
+});
+
+function setSingleAccordion(item) {
+    item.addEventListener('click', function () {
+        this.classList.toggle('active');
+        this.querySelector('.arrow').classList.toggle('activeArrow');
+        var panel = this.nextElementSibling;
+        if (panel.style.maxHeight) {
+            panel.style.maxHeight = null;
+        } else {
+            let paddingTop = +panel.querySelector('.paddingDiv').style.paddingTop.split('px')[0];
+            let paddingBottom = +panel.querySelector('.paddingDiv').style.paddingBottom.split('px')[0];
+            panel.style.maxHeight = (panel.scrollHeight + paddingTop + paddingBottom) + 'px';
+        }
+    });
+}
+
+function setTableSorter() {
+    let items = document.getElementsByTagName('TH');
+    for (let i = 0; i < items.length; i++) {
+        items[i].addEventListener('click', () => {
+            sortTable(i)
+        });
+    }
+}
+
+function setLogBtnListener(item) {
+    item.addEventListener('click', function () {
+        const id = this.id.substring('Log'.length);
+        vscode.postMessage({
+            logRequest: {
+                'id': id
+            }
+        });
+    });
+}
+
+function setLoadMoreListener() {
+    let item = document.querySelector("#loadBtn");
+    item.addEventListener('click', function () {
+        vscode.postMessage({
+            loadMore: true
+        });
+    });
+}
+
+function setDigestListener(digestClickables) {
+    for (digest of digestClickables) {
+        digest.addEventListener('click', function () {
+            modalObject.modal.querySelector('#digestVisualizer').value = this.parentNode.dataset.digest;
+            modalObject.modal.style.display = 'flex';
+            modalObject.overlay.style.display = 'flex';
+        });
+    }
+}

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -18,7 +18,6 @@ let content = document.querySelector('#core');
 const vscode = acquireVsCodeApi();
 setLoadMoreListener();
 setTableSorter();
-window.addEventListener("resize", manageWidth);
 
 modalObject.overlay.addEventListener('click', (event) => {
     if (event.target === modalObject.overlay) {
@@ -42,13 +41,13 @@ function sortTable(n, dir = "asc", holdDir = false) {
     currentN = n;
     let table, rows, switching, i, x, y, shouldSwitch, switchcount = 0;
     let cmpFunc = acquireCompareFunction(n);
-    table = document.getElementById("coreParent");
+    table = document.getElementById("core");
     switching = true;
     //Set the sorting direction to ascending:
 
     while (switching) {
         switching = false;
-        rows = table.querySelectorAll(".accordion");
+        rows = table.querySelectorAll(".holder");
         for (i = 0; i < rows.length - 1; i++) {
             shouldSwitch = false;
             x = rows[i].getElementsByTagName("TD")[n];
@@ -133,6 +132,7 @@ window.addEventListener('message', event => {
     } else if (message.type === 'endContinued') {
         sortTable(currentN, currentDir, true);
     } else if (message.type === 'end') {
+        window.addEventListener("resize", manageWidth);
         manageWidth();
     }
 
@@ -142,11 +142,17 @@ function setSingleAccordion(item) {
     item.addEventListener('click', function () {
         this.classList.toggle('active');
         this.querySelector('.arrow').classList.toggle('activeArrow');
-        var panel = this.nextElementSibling;
+        let panel = this.nextElementSibling;
         if (panel.style.maxHeight) {
             panel.style.display = 'none';
             panel.style.maxHeight = null;
+            let index = openAccordions.indexOf(panel);
+            if (index > -1) {
+                openAccordions.splice(index, 1);
+            }
         } else {
+            openAccordions.push(panel);
+            setAccordionTableWidth();
             panel.style.display = 'table-row';
             let paddingTop = +panel.style.paddingTop.split('px')[0];
             let paddingBottom = +panel.style.paddingBottom.split('px')[0];
@@ -201,5 +207,34 @@ function manageWidth() {
     for (let i = 0; i < topRowCells.length; i++) {
         let width = parseInt(getComputedStyle(topRowCells[i]).width);
         headerCells[i].style.width = width + "px";
+    }
+    setAccordionTableWidth();
+}
+
+let openAccordions = [];
+
+function setAccordionTableWidth() {
+    let topRow = document.querySelector("#core tr");
+    let topRowCells = topRow.querySelectorAll("td");
+    let topWidths = [];
+    for (let cell of topRowCells) {
+        topWidths.push(parseInt(getComputedStyle(cell).width));
+    }
+    for (acc of openAccordions) {
+        let cells = acc.querySelectorAll(".innerTable td");
+        cells[0].style.width = topWidths[0];
+        cells[5].style.width = topWidths[1] + topWidths[2] + topWidths[3] + topWidths[4] + topWidths[5];
+        cells[2].style.width = topWidths[6];
+        for (let i = 3; i < cells.length; i++) {
+            if ((i + 2) % 4 === 1) {
+                cells[i].style.width = topWidths[0] + "px";
+            } else if ((i + 2) % 4 === 2) {
+                cells[i].style.width = (topWidths[1] + topWidths[2]) + "px";
+            } else if ((i + 2) % 4 === 3) {
+                cells[i].style.width = (topWidths[3] + topWidths[4]) + "px";
+            } else if ((i + 2) % 4 === 0) {
+                cells[i].style.width = topWidths[5] + "px";
+            }
+        }
     }
 }

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -13,6 +13,11 @@ var modalObject = {
     overlay: document.querySelector('.overlay')
 };
 
+var triangles = {
+    'down': ' △',
+    'up': ' ▽'
+}
+
 // Main
 let content = document.querySelector('#core');
 const vscode = acquireVsCodeApi();
@@ -76,6 +81,19 @@ function sortTable(n, dir = "asc", holdDir = false) {
             }
         }
     }
+
+    let sortColumns = document.querySelectorAll(".sort");
+    if (sortColumns[n - 1].innerHTML === triangles['down']) {
+        sortColumns[n - 1].innerHTML = triangles['up'];
+    } else if (sortColumns[n - 1].innerHTML === triangles['up']) {
+        sortColumns[n - 1].innerHTML = triangles['down'];
+    } else {
+        for (cell of sortColumns) {
+            cell.innerHTML = '  ';
+        }
+        sortColumns[n - 1].innerHTML = triangles['down'];
+    }
+
 }
 
 function acquireCompareFunction(n) {

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -89,14 +89,19 @@ function acquireCompareFunction(n) {
             return (x, y) => {
                 return status[x.innerHTML] > status[y.innerHTML];;
             }
-        case 3: //Start time
-        case 4: // Finish time
+        case 3: //Created time
             return (x, y) => {
-                if (x.innerHTML === '?') return true;
-                if (y.innerHTML === '?') return false;
+                if (x.innerHTML === '') return true;
+                if (y.innerHTML === '') return false;
                 let dateX = new Date(x.innerHTML);
                 let dateY = new Date(y.innerHTML);
                 return dateX > dateY;
+            }
+        case 4: //Elapsed time
+            return (x, y) => {
+                if (x.innerHTML === '') return true;
+                if (y.innerHTML === '') return false;
+                return (+x.innerHTML.substring(0, x.innerHTML.length)) > (+y.innerHTML.substring(0, x.innerHTML.length));
             }
         case 5: //OS Type
             return (x, y) => {

--- a/commands/azureCommands/acr-build-logs-utils/logScripts.js
+++ b/commands/azureCommands/acr-build-logs-utils/logScripts.js
@@ -198,11 +198,8 @@ function manageWidth() {
     let headerCells = document.querySelectorAll("#headerTable th");
     let topRow = document.querySelector("#core tr");
     let topRowCells = topRow.querySelectorAll("td");
-    console.log(topRowCells);
     for (let i = 0; i < topRowCells.length; i++) {
         let width = parseInt(getComputedStyle(topRowCells[i]).width);
-        console.log(width);
         headerCells[i].style.width = width + "px";
     }
 }
-

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -99,7 +99,7 @@ body {
 }
 
 .innerTable {
-    width: 85%;
+    width: 87%;
     align-content: left;
     text-align: left;
 }
@@ -120,8 +120,8 @@ body {
 
 table {
     border-collapse: collapse;
-    width: 95%;
-    margin-left: 5%;
+    width: 98%;
+    margin-left: 2%;
 }
 
 .innerTable td,
@@ -134,7 +134,7 @@ table {
     justify-content: center;
     align-content: center;
     align-items: center;
-    width: 10%;
+    width: 13%;
 }
 
 .viewLog {
@@ -163,25 +163,20 @@ table {
 }
 
 .arrow {
-    width: 25%;
-    padding-top: 25%;
     transform: rotate(45deg);
-    border-left: none;
-    border-top: none;
-    border-right: 2px var(--vscode-editor-foreground) solid;
-    border-bottom: 2px var(--vscode-editor-foreground) solid;
     -webkit-transition: -webkit-transform .2s ease-in-out;
     transition: transform .2s ease-in-out;
 }
 
 .activeArrow {
-    -webkit-transform: rotate(225deg);
-    transform: rotate(225deg);
+    -webkit-transform: rotate(90deg);
+    transform: rotate(90deg);
 }
 
 .paddingDiv {
     display: flex;
-    width: 100%;
+    width: 96.5%;
+    margin-left: 3.5%;
     padding-top: 10px;
     padding-bottom: 10px;
 }
@@ -228,4 +223,14 @@ table {
 
 #digestVisualizer {
     width: 85%;
+}
+
+.arrowHolder {
+    width: 4.3%;
+    padding-left: 1.5%;
+    padding-right: 1.5%;
+}
+
+.overflowX {
+    overflow-x: auto;
 }

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -55,24 +55,36 @@ table {
     width: 100%;
 }
 
+.innerTable .borderLimit {
+    padding-left: 0px;
+}
+
 .widthControl {
+    box-sizing: border-box;
     text-align: left;
-    width: 15.95%;
+    width: calc(15.45%);
+    padding-left: 0.7cm;
 }
 
 .widthControl2 {
+    box-sizing: border-box;
     text-align: left;
-    width: 31.9%;
+    width: calc(30.9%);
+    padding-left: 0.7cm;
 }
 
 .widthControl3 {
+    box-sizing: border-box;
     text-align: left;
-    width: 47.85%;
+    width: calc(46.35%);
+    padding-left: 0.7cm;
 }
 
 .widthControl5 {
+    box-sizing: border-box;
     text-align: left;
-    width: 79.75%;
+    width: calc(77.25%);
+    padding-left: 0.7cm;
 }
 
 #header {
@@ -126,6 +138,7 @@ body {
 
 .innerTable td.arrowHolder {
     border-bottom: 0px;
+    padding-right: 0.7cm;
 }
 
 .innerTable td,

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -3,7 +3,7 @@
     color: var(--color);
     cursor: pointer;
     margin: 0px;
-    padding: 5px 0px;
+    height: 30px;
     width: 100%;
     border: none;
     text-align: left;
@@ -29,7 +29,7 @@
 
 .panel {
     width: 100%;
-    display: flex;
+    display: none;
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.2s ease-out;
@@ -51,7 +51,9 @@
 
 table {
     text-align: left;
+    border-collapse: collapse;
     width: 100%;
+    padding-left: 2%;
 }
 
 .widthControl {
@@ -99,7 +101,7 @@ body {
 }
 
 .innerTable {
-    width: 87%;
+    width: 85%;
     align-content: left;
     text-align: left;
 }
@@ -118,10 +120,8 @@ body {
     border-bottom: 0px;
 }
 
-table {
-    border-collapse: collapse;
-    width: 98%;
-    margin-left: 2%;
+.innerTable td.lastTd {
+    border-bottom: 0px;
 }
 
 .innerTable td,
@@ -175,8 +175,7 @@ table {
 
 .paddingDiv {
     display: flex;
-    width: 96.5%;
-    margin-left: 3.5%;
+    width: 100%;
     padding-top: 10px;
     padding-bottom: 10px;
 }
@@ -229,6 +228,7 @@ table {
     width: 4.3%;
     padding-left: 1.5%;
     padding-right: 1.5%;
+    text-align: center;
 }
 
 .overflowX {

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -84,7 +84,7 @@ table {
 }
 
 #header {
-    height: 0.8cm;
+    height: 1cm;
     top: 0px;
     position: fixed;
     width: 100%;
@@ -100,9 +100,10 @@ h2 {
     font-family: var(--vscode-editor-font-family);
 }
 
-#core {
-    margin-top: 0.8cm;
+#coreParent{
+    margin-top: 1cm;
 }
+
 
 #headerTable {
     font-size: var(--vscode-editor-font-size);

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -1,0 +1,231 @@
+.accordion {
+    background-color: var(--vscode-editor-background);
+    color: var(--color);
+    cursor: pointer;
+    margin: 0px;
+    padding: 5px 0px;
+    width: 100%;
+    border: none;
+    text-align: left;
+    outline: none;
+    font-size: var(--vscode-editor-font-size);
+    font-family: var(--vscode-editor-font-family);
+    transition: 0.4s;
+    text-align: left;
+}
+
+.accordion:hover {
+    cursor: pointer;
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+.active {
+    background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+.active.accordion:hover {
+    background-color: var(--vscode-list-activeSelectionBackground);
+}
+
+.panel {
+    width: 100%;
+    display: flex;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+.status.Failed {
+    color: var(--vscode-terminal-ansiBrightRed);
+    font-weight: bold;
+}
+
+.status.Running {
+    color: var(--vscode-terminal-ansiBlue);
+}
+
+.status.Error {
+    color: var(--vscode-terminal-ansiYellow);
+}
+
+table {
+    text-align: left;
+    width: 100%;
+}
+
+.widthControl {
+    text-align: left;
+    width: 16.45%;
+}
+
+#header {
+    height: 0.8cm;
+    top: 0px;
+    position: fixed;
+    width: 100%;
+    z-index: 1;
+    display: block;
+    background-color: var(--vscode-activityBar-background);
+    color: var(--vscode-activityBar-foreground);
+}
+
+h2 {
+    padding-left: 10px;
+    font-size: var(--vscode-editor-font-size);
+    font-family: var(--vscode-editor-font-family);
+}
+
+#core {
+    margin-top: 0.8cm;
+}
+
+#headerTable {
+    font-size: var(--vscode-editor-font-size);
+    font-family: var(--vscode-editor-font-family);
+    cursor: pointer;
+    height: 100%;
+}
+
+body {
+    padding: 0px;
+    width: 100%;
+    color: var(--color);
+}
+
+.logConsole {
+    height: 100px;
+    overflow-y: auto;
+}
+
+.innerTable {
+    width: 85%;
+    align-content: left;
+    text-align: left;
+}
+
+.innerTable td {
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+    width: 28.33%;
+}
+
+.innerTable tr {
+    border-bottom: 1px solid var(--vscode-editor-foreground);
+}
+
+.innerTable tr.lastTr {
+    border-bottom: 0px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 95%;
+    margin-left: 5%;
+}
+
+.innerTable td,
+.innerTable th {
+    text-align: left;
+}
+
+.button-holder {
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    width: 10%;
+}
+
+.viewLog {
+    background-color: var(--vscode-button-background);
+    border: none;
+    color: var(--vscode-button-foreground);
+    padding: 5px 13px;
+    text-align: left;
+    text-decoration: none;
+    display: inline-block;
+    font-size: var(--vscode-editor-font-size);
+    cursor: pointer;
+    align-items: left;
+}
+
+.loadMoreBtn {
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    width: 100%;
+}
+
+.viewLog:hover {
+    background-color: var(--vscode-button-hoverBackground);
+}
+
+.arrow {
+    width: 25%;
+    padding-top: 25%;
+    transform: rotate(45deg);
+    border-left: none;
+    border-top: none;
+    border-right: 2px var(--vscode-editor-foreground) solid;
+    border-bottom: 2px var(--vscode-editor-foreground) solid;
+    -webkit-transition: -webkit-transform .2s ease-in-out;
+    transition: transform .2s ease-in-out;
+}
+
+.activeArrow {
+    -webkit-transform: rotate(225deg);
+    transform: rotate(225deg);
+}
+
+.paddingDiv {
+    display: flex;
+    width: 100%;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.copy:hover {
+    cursor: pointer;
+}
+
+.overlay {
+    display: none;
+    position: fixed;
+    justify-content: center;
+    align-content: center;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+    background-color: rgba(0, 0, 0, 0.5);
+    /*dim the background*/
+}
+
+.modal {
+    margin: auto;
+    display: none;
+    width: 40%;
+    z-index: 11;
+}
+
+.copyBtn {
+    background-color: var(--vscode-button-background);
+    border: none;
+    color: var(--vscode-button-foreground);
+    padding: 5px 13px;
+    text-align: left;
+    text-decoration: none;
+    display: inline-block;
+    font-size: var(--vscode-editor-font-size);
+    cursor: pointer;
+    align-items: left;
+}
+
+#digestVisualizer {
+    width: 85%;
+}

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -100,10 +100,9 @@ h2 {
     font-family: var(--vscode-editor-font-family);
 }
 
-#coreParent{
+#core {
     margin-top: 1cm;
 }
-
 
 #headerTable {
     font-size: var(--vscode-editor-font-size);

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -53,12 +53,26 @@ table {
     text-align: left;
     border-collapse: collapse;
     width: 100%;
-    padding-left: 2%;
 }
 
 .widthControl {
     text-align: left;
-    width: 16.45%;
+    width: 15.95%;
+}
+
+.widthControl2 {
+    text-align: left;
+    width: 31.9%;
+}
+
+.widthControl3 {
+    text-align: left;
+    width: 47.85%;
+}
+
+.widthControl5 {
+    text-align: left;
+    width: 79.75%;
 }
 
 #header {
@@ -100,27 +114,17 @@ body {
     overflow-y: auto;
 }
 
-.innerTable {
-    width: 85%;
-    align-content: left;
-    text-align: left;
-}
-
 .innerTable td {
+    border-bottom: 1px solid var(--vscode-editor-foreground);
     font-family: var(--vscode-editor-font-family);
     font-size: var(--vscode-editor-font-size);
-    width: 28.33%;
-}
-
-.innerTable tr {
-    border-bottom: 1px solid var(--vscode-editor-foreground);
-}
-
-.innerTable tr.lastTr {
-    border-bottom: 0px;
 }
 
 .innerTable td.lastTd {
+    border-bottom: 0px;
+}
+
+.innerTable td.arrowHolder {
     border-bottom: 0px;
 }
 
@@ -134,7 +138,7 @@ body {
     justify-content: center;
     align-content: center;
     align-items: center;
-    width: 13%;
+    width: 100%;
 }
 
 .viewLog {

--- a/commands/azureCommands/acr-build-logs-utils/stylesheet.css
+++ b/commands/azureCommands/acr-build-logs-utils/stylesheet.css
@@ -55,36 +55,32 @@ table {
     width: 100%;
 }
 
-.innerTable .borderLimit {
-    padding-left: 0px;
-}
-
 .widthControl {
     box-sizing: border-box;
     text-align: left;
-    width: calc(15.45%);
-    padding-left: 0.7cm;
+    width: calc(15.9%);
+    padding-right: 0.7cm;
 }
 
 .widthControl2 {
     box-sizing: border-box;
     text-align: left;
-    width: calc(30.9%);
-    padding-left: 0.7cm;
+    width: calc(31.8%);
+    padding-right: 0.7cm;
 }
 
 .widthControl3 {
     box-sizing: border-box;
     text-align: left;
-    width: calc(46.35%);
-    padding-left: 0.7cm;
+    width: calc(47.7%);
+    padding-right: 0.7cm;
 }
 
 .widthControl5 {
     box-sizing: border-box;
     text-align: left;
-    width: calc(77.25%);
-    padding-left: 0.7cm;
+    width: calc(79.5%);
+    padding-right: 0.7cm;
 }
 
 #header {
@@ -147,11 +143,13 @@ body {
 }
 
 .button-holder {
+    box-sizing: border-box;
     display: flex;
     justify-content: center;
     align-content: center;
     align-items: center;
     width: 100%;
+    padding-left: 0.7cm;
 }
 
 .viewLog {
@@ -159,12 +157,12 @@ body {
     border: none;
     color: var(--vscode-button-foreground);
     padding: 5px 13px;
-    text-align: left;
+    text-align: center;
     text-decoration: none;
     display: inline-block;
     font-size: var(--vscode-editor-font-size);
     cursor: pointer;
-    align-items: left;
+    align-items: center;
 }
 
 .loadMoreBtn {
@@ -242,9 +240,9 @@ body {
 }
 
 .arrowHolder {
-    width: 4.3%;
-    padding-left: 1.5%;
-    padding-right: 1.5%;
+    box-sizing: border-box;
+    width: 4.6%;
+    padding-right: 0.7cm;
     text-align: center;
 }
 

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -199,13 +199,11 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
                 <td></td>
             </table>
         </div>
-        <div class = "offsetX">
             <table>
                 <tbody id = 'core'>
 
                 </tbody>
             </table>
-        </div>
         <div class = 'loadMoreBtn'>
             <button id= "loadBtn" class="viewLog">Load More Logs</button>
         </div>

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -95,39 +95,35 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
             'type': 'populate',
             'id': i,
             'logComponent': `
-                    <div class = "holder">
-                        <button id= "btn${i}" class="accordion">
-                            <table>
-                                <tr>
-                                    <td class = 'arrowHolder'><div class = "arrow">&#x25f9</div></td>
-                                    <td class = 'widthControl'>${name}</td>
-                                    <td class = 'widthControl'>${buildTask}</td>
-                                    <td class ='status widthControl ${log.status}'>${log.status}</td>
-                                    <td class = 'widthControl'>${createTime}</td>
-                                    <td class = 'widthControl'>${timeElapsed}</td>
-                                    <td class = 'widthControl'>${osType}</td>
-                                </tr>
-                            </table>
-                        </button>
-                        <div class="panel">
-                            <div class= "paddingDiv">
-                                <table class="innerTable">
-                                    <tr>
-                                        <td colspan="3">Output Images</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Tag</th>
-                                        <td>Repository</td>
-                                        <td>Digest</td>
-                                    </tr>
-                                    ${imageOutput}
-                                </table>
-                                <div class = 'button-holder'>
-                                    <button id= "log${i}" class="viewLog">Open Logs</button>
+                        <tr id= "btn${i}" class="accordion">
+                                <td class = 'arrowHolder'><div class = "arrow">&#x25f9</div></td>
+                                <td class = 'widthControl'>${name}</td>
+                                <td class = 'widthControl'>${buildTask}</td>
+                                <td class ='status widthControl ${log.status}'>${log.status}</td>
+                                <td class = 'widthControl'>${createTime}</td>
+                                <td class = 'widthControl'>${timeElapsed}</td>
+                                <td class = 'widthControl'>${osType}</td>
+                        </tr>
+                        <tr class="panel">
+                            <td colspan = "7">
+                                <div class= "paddingDiv">
+                                    <table class="innerTable">
+                                        <tr>
+                                            <td colspan="3">Output Images</td>
+                                            <td class = "lastTd" rowspan = "300">
+                                                <button id= "log${i}" class="viewLog">Open Logs</button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Tag</th>
+                                            <td>Repository</td>
+                                            <td>Digest</td>
+                                        </tr>
+                                        ${imageOutput}
+                                    </table>
                                 </div>
-                            </div>
-                        </div>
-                    </div>`
+                            </td>
+                        </tr>`
         });
     }
     if (startItem) {
@@ -197,7 +193,12 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
                 <td></td>
             </table>
         </div>
-        <div id = 'core'>
+        <div class = "offsetX">
+            <table>
+                <tbody id = 'core'>
+
+                </tbody>
+            </table>
         </div>
         <div class = 'loadMoreBtn'>
             <button id= "loadBtn" class="viewLog">Load More Logs</button>
@@ -246,6 +247,10 @@ function createLogView(text: string, title: string): void {
     } catch (error) {
         console.log(error);
     }
+
+    // vscode.workspace.openTextDocument(uri).then((doc) => {
+    //     return vscode.window.showTextDocument(doc, vscode.ViewColumn.Active + 1, true);
+    // });
 
     vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, title).then(_ => { }, _ => {
         vscode.window.showErrorMessage('Cant open!');

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -1,11 +1,11 @@
+import ContainerRegistryManagementClient from "azure-arm-containerregistry";
 import { Build, BuildGetLogResult, BuildListResult, BuildTaskListResult, Registry, RegistryListResult, RegistryNameStatus } from "azure-arm-containerregistry/lib/models";
+import { Subscription } from "azure-arm-resource/lib/subscription/models";
 import { BlobService, createBlobServiceWithSas } from "azure-storage";
+import { truncate } from "fs-extra";
 import * as path from 'path';
 import * as vscode from "vscode";
 import { AzureImageNode, AzureLoadingNode, AzureNotSignedInNode, AzureRegistryNode, AzureRepositoryNode } from '../../explorer/models/azureRegistryNodes';
-import { truncate } from "../../node_modules/@types/fs-extra";
-import ContainerRegistryManagementClient from "../../node_modules/azure-arm-containerregistry";
-import { Subscription } from "../../node_modules/azure-arm-resource/lib/subscription/models";
 import { getSubscriptionFromRegistry } from '../../utils/Azure/acrTools';
 import { AzureUtilityManager } from '../../utils/azureUtilityManager';
 import { quickPickACRRegistry } from '../utils/quick-pick-azure'
@@ -199,7 +199,7 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
                 <td></td>
             </table>
         </div>
-            <table>
+            <table id = 'coreParent'>
                 <tbody id = 'core'>
 
                 </tbody>

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -110,7 +110,7 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
                                     <table class="innerTable">
                                         <tr>
                                             <td class = "arrowHolder">&#160</td>
-                                            <td colspan = "5" class = "widthControl5">Output Images</td>
+                                            <td colspan = "5" class = "borderLimit widthControl5">Output Images</td>
                                             <td class = "widthControl lastTd" rowspan = "300">
                                                 <div class = "button-holder">
                                                     <button id= "log${i}" class="viewLog">Open Logs</button>
@@ -119,9 +119,9 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
                                         </tr>
                                         <tr>
                                             <td class = "arrowHolder">&#160</td>
-                                            <td colspan = "2" class = 'widthControl2'>Tag</th>
-                                            <td colspan = "2" class = 'widthControl3'>Repository</td>
-                                            <td class = 'widthControl'>Digest</td>
+                                            <td colspan = "2" class = "borderLimit widthControl2">Tag</th>
+                                            <td colspan = "2" class = "widthControl3">Repository</td>
+                                            <td class = "widthControl">Digest</td>
                                         </tr>
                                         ${imageOutput}
                                     </table>
@@ -151,7 +151,7 @@ function getImageOutputTable(log: Build): string {
                 const lastTd: string = j === log.outputImages.length - 1 ? 'lastTd' : '';
                 imageOutput += `<tr>
                                     <td class = "arrowHolder">&#160</td>
-                                    <td colspan = "2" class = "widthControl2 ${lastTd}">${tag}</td>
+                                    <td colspan = "2" class = "borderLimit widthControl2 ${lastTd}">${tag}</td>
                                     <td colspan = "2" class = "widthControl2 ${lastTd}">${repository}</td>
                                     <td colspan = "1" class = "widthControl ${lastTd}" data-digest = "${digest}">${truncatedDigest} <inline class = 'copy'>&#128459</inline></td>
                                 </tr>`;
@@ -166,7 +166,7 @@ function getImageOutputTable(log: Build): string {
     if (needsNA) {
         imageOutput += `<tr>
                             <td class = "arrowHolder lastTd">&#160</td>
-                            <td colspan = "2" class = "widthControl2 lastTd">NA</td>
+                            <td colspan = "2" class = "borderLimit widthControl2 lastTd">NA</td>
                             <td colspan = "2" class = "widthControl2 lastTd">NA</td>
                             <td colspan = "1" class = "widthControl lastTd">NA</td>
                         </tr>`;

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -1,0 +1,395 @@
+import { Build, BuildGetLogResult, BuildListResult, BuildTaskListResult, Registry, RegistryListResult, RegistryNameStatus } from "azure-arm-containerregistry/lib/models";
+import { BlobService, createBlobServiceWithSas } from "azure-storage";
+import * as path from 'path';
+import * as vscode from "vscode";
+import { AzureImageNode, AzureLoadingNode, AzureNotSignedInNode, AzureRegistryNode, AzureRepositoryNode } from '../../explorer/models/azureRegistryNodes';
+import { truncate } from "../../node_modules/@types/fs-extra";
+import ContainerRegistryManagementClient from "../../node_modules/azure-arm-containerregistry";
+import { Subscription } from "../../node_modules/azure-arm-resource/lib/subscription/models";
+import { getSubscriptionFromRegistry } from '../../utils/Azure/acrTools';
+import { AzureUtilityManager } from '../../utils/azureUtilityManager';
+import { quickPickACRRegistry } from '../utils/quick-pick-azure'
+
+const teleCmdId: string = 'vscode-docker.buildTaskLog';
+
+/**  This command is used through a right click on an azure registry, repository or image in the Docker Explorer. It is used to view build logs for a given item. */
+export async function viewBuildLogs(context: AzureRegistryNode | AzureRepositoryNode | AzureImageNode): Promise<void> {
+    let registry: Registry;
+    let subscription: Subscription;
+    if (!context) {
+        registry = await quickPickACRRegistry();
+        if (!registry) { return; }
+        subscription = getSubscriptionFromRegistry(registry);
+    } else {
+        registry = context.registry;
+        subscription = context.subscription;
+    }
+    let resourceGroup: string = registry.id.slice(registry.id.search('resourceGroups/') + 'resourceGroups/'.length, registry.id.search('/providers/'));
+
+    const client = AzureUtilityManager.getInstance().getContainerRegistryManagementClient(subscription);
+    let logData: LogData = new LogData(client, registry, resourceGroup);
+    const filterFunction = context ? getFilterFunction(context) : undefined;
+    try {
+        await logData.loadMoreLogs(filterFunction);
+    } catch (error) {
+        if (error.code !== "NoRegisteredProviderFound") {
+            throw error;
+        }
+    }
+
+    if (logData.logs.length === 0) {
+        let itemType: string;
+        if (context && context instanceof AzureRepositoryNode) {
+            itemType = 'repository';
+        } else if (context && context instanceof AzureImageNode) {
+            itemType = 'image';
+        } else {
+            itemType = 'registry';
+        }
+        vscode.window.showInformationMessage(`This ${itemType} has no associated build logs`);
+        return;
+    }
+
+    let links: { url?: string, id: number }[] = [];
+
+    links.sort((a, b): number => { return a.id - b.id });
+    let webViewTitle: string = registry.name;
+    if (context instanceof AzureRepositoryNode || context instanceof AzureImageNode) {
+        webViewTitle += (context ? '/' + context.label : '');
+    }
+    createWebview(webViewTitle, logData);
+
+}
+
+//# WEBVIEW COMPONENTS
+/** Generate the webview to display the logs */
+function createWebview(webviewName: string, logData: LogData): void {
+    //Creating the panel in which to show the logs
+    const panel = vscode.window.createWebviewPanel('log Viewer', webviewName, vscode.ViewColumn.One, { enableScripts: true, retainContextWhenHidden: true });
+
+    //Get path to resource on disk
+    let extensionPath = vscode.extensions.getExtension("PeterJausovec.vscode-docker").extensionPath;
+    const scriptPath = vscode.Uri.file(path.join(extensionPath, 'commands', 'azureCommands', 'acr-build-logs-utils', 'logScripts.js'));
+    const scriptFile = scriptPath.with({ scheme: 'vscode-resource' });
+    const stylePath = vscode.Uri.file(path.join(extensionPath, 'commands', 'azureCommands', 'acr-build-logs-utils', 'stylesheet.css'));
+    const styleFile = stylePath.with({ scheme: 'vscode-resource' });
+
+    //Populate Webview
+    panel.webview.html = getWebviewContent(scriptFile, styleFile);
+    addLogsToWebView(panel, logData);
+}
+/** Communicates with the webview javascript file through post requests to populate the log table */
+function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startItem?: number): void {
+    const begin = startItem ? startItem : 0;
+    if (!startItem) { setupCommunication(panel, logData); }
+    for (let i = begin; i < logData.logs.length; i++) {
+        const log = logData.logs[i];
+        const buildTask: string = log.buildTask ? log.buildTask : '';
+        const createTime: string = log.createTime ? log.createTime.toLocaleString() : '';
+        const timeElapsed: string = log.startTime && log.finishTime ? (Math.abs(log.startTime.valueOf() - log.finishTime.valueOf()) / 1000).toString() : '';
+        const osType: string = log.platform.osType ? log.platform.osType : '';
+        const name: string = log.name ? log.name : '';
+        let imageOutput: string = getImageOutputTable(log);
+
+        panel.webview.postMessage({
+            'type': 'populate',
+            'id': i,
+            'logComponent': `
+                    <div class = "holder">
+                        <button id= "btn${i}" class="accordion">
+                            <table>
+                                <tr>
+                                    <td class = 'widthControl'>${name}</td>
+                                    <td class = 'widthControl'>${buildTask}</td>
+                                    <td class ='status widthControl ${log.status}'>${log.status}</td>
+                                    <td class = 'widthControl'>${createTime}</td>
+                                    <td class = 'widthControl'>${timeElapsed}s</td>
+                                    <td class = 'widthControl'>${osType}</td>
+                                    <td><div class = "arrow"></div></td>
+                                </tr>
+                            </table>
+                        </button>
+                        <div class="panel">
+                            <div class= "paddingDiv">
+                                <table class="innerTable">
+                                    <tr>
+                                        <td colspan="3">Output Images</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Tag</th>
+                                        <td>Repository</td>
+                                        <td>Digest</td>
+                                    </tr>
+                                    ${imageOutput}
+                                </table>
+                                <div class = 'button-holder'>
+                                    <button id= "log${i}" class="viewLog">Open Logs</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>`
+        });
+    }
+    if (startItem) {
+        panel.webview.postMessage({ 'type': 'endContinued' });
+    } else {
+        panel.webview.postMessage({ 'type': 'end' });
+    }
+}
+
+function getImageOutputTable(log: Build): string {
+    let imageOutput: string = '';
+    let needsNA: boolean = false;
+    if (log.outputImages) {
+        for (let j = 0; j < log.outputImages.length; j++) {
+            let img = log.outputImages[j]
+            if (img) {
+                const tag: string = img.tag ? img.tag : '';
+                const repository: string = img.repository ? img.repository : '';
+                const digest: string = img.digest ? img.digest : '';
+                const truncatedDigest: string = digest ? digest.substr(0, 5) + '...' + digest.substr(digest.length - 5) : '';
+                const lastTr: string = j === log.outputImages.length - 1 ? 'class = "lastTr"' : '';
+                imageOutput += `<tr ${lastTr}>
+                                        <td>${tag}</td>
+                                        <td>${repository}</td>
+                                        <td data-digest = "${digest}">${truncatedDigest} <inline class = 'copy'>&#128459</inline></td>
+                                    </tr>`;
+            }
+        }
+        if (!log.outputImages[0]) {
+            needsNA = true;
+        }
+    } else {
+        needsNA = true;
+    }
+    if (needsNA) {
+        imageOutput += `<tr class = "lastTr">
+                                    <td>NA</td>
+                                    <td>NA</td>
+                                    <td>NA</td>
+                                </tr>`;
+    }
+    return imageOutput;
+}
+
+/** Create the table in which to push the build logs */
+function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): string {
+    return `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <link rel="stylesheet" type="text/css" href="${stylesheet}">
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="frame-src vscode-resource:; img-src vscode-resource: https:; script-src vscode-resource:; style-src vscode-resource:;">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Logs</title>
+    </head>
+
+    <body>
+        <div id = "header">
+            <table id="headerTable">
+                <th class = 'widthControl'>Build Name </th>
+                <th class = 'widthControl'>BuildTask </th>
+                <th class = 'widthControl'>Status </th>
+                <th class = 'widthControl'>Created </th>
+                <th class = 'widthControl'>Elapsed Time </th>
+                <th class = 'widthControl'>Platform </th>
+                <td></td>
+            </table>
+        </div>
+        <div id = 'core'>
+        </div>
+        <div class = 'loadMoreBtn'>
+            <button id= "loadBtn" class="viewLog">Load More Logs</button>
+        </div>
+        <div class="overlay">
+            <div class="modal">
+                <input id = "digestVisualizer", readonly>
+                <button class = "copyBtn">Copy</button>
+            </div>
+        </div>
+
+        <script src= "${scriptFile}"></script>
+    </body>
+`;
+}
+/** Setup communication with the webview sorting out received mesages from its javascript file */
+function setupCommunication(panel: vscode.WebviewPanel, logData: LogData): void {
+    panel.webview.onDidReceiveMessage(async (message) => {
+        if (message.logRequest) {
+            const itemNumber: number = +message.logRequest.id;
+            logData.getLink(itemNumber).then((url) => {
+                if (url !== 'requesting') {
+                    openLog(url, logData.logs[itemNumber].buildId);
+                }
+            })
+        } else if (message.loadMore) {
+            try {
+                await logData.loadMoreLogs();
+            } catch (error) {
+                vscode.window.showErrorMessage(error.message);
+            }
+
+            addLogsToWebView(panel, logData, logData.logs.length);
+        }
+    });
+}
+
+//# LOGS
+/** Passes the log text into a document provider */
+function createLogView(text: string, title: string): void {
+    const scheme = 'purejs';
+    let uri: vscode.Uri;
+    try {
+        let query = JSON.stringify({ 'log': makeBase64(text) });
+        uri = vscode.Uri.parse(`${scheme}://authority/${title}?${query}#idk`);
+    } catch (error) {
+        console.log(error);
+    }
+
+    vscode.commands.executeCommand('vscode.previewHtml', uri, undefined, title).then(_ => { }, _ => {
+        vscode.window.showErrorMessage('Cant open!');
+    });
+}
+/** Loads log text from remote url using azure blobservices */
+function openLog(url: string, title: string): void {
+    let blobInfo = getBlobInfo(url);
+    let blob: BlobService;
+    try {
+        blob = createBlobServiceWithSas(blobInfo.host, blobInfo.sasToken);
+    } catch (error) {
+        console.log(error);
+    }
+    try {
+        blob.getBlobToText(blobInfo.containerName, blobInfo.blobName, async (error, text, result, response) => {
+            if (response) {
+                createLogView(text, title);
+            } else {
+                console.log(error);
+            }
+        });
+    } catch (error) {
+        console.log(error);
+    }
+}
+/** Parses blob url into a readable form */
+function getBlobInfo(blobUrl: string): { accountName: string, endpointSuffix: string, containerName: string, blobName: string, sasToken: string, host: string } {
+    const items: string[] = blobUrl.slice(blobUrl.search('https://') + 'https://'.length).split('/');
+    const accountName: string = blobUrl.slice(blobUrl.search('https://') + 'https://'.length, blobUrl.search('.blob'));
+    const endpointSuffix: string = items[0].slice(items[0].search('.blob.') + '.blob.'.length);
+    const containerName: string = items[1];
+    const blobName: string = items[2] + '/' + items[3] + '/' + items[4].slice(0, items[4].search('[?]'));
+    const sasToken: string = items[4].slice(items[4].search('[?]') + 1);
+    const host: string = accountName + '.blob.' + endpointSuffix;
+    return { accountName, endpointSuffix, containerName, blobName, sasToken, host };
+}
+
+//# UTILS
+function makeBase64(str: string): string {
+    let buffer = new Buffer(str);
+    return buffer.toString('base64');
+}
+
+/** Obtains a function to filter logs to a single repository/image */
+function getFilterFunction(context: AzureRegistryNode | AzureRepositoryNode | AzureImageNode): (logEntry: Build) => boolean {
+    if (context instanceof AzureRegistryNode) {
+        return undefined;
+    } else if (context instanceof AzureRepositoryNode) {
+        return (logEntry: Build) => {
+            if (!logEntry.outputImages) {
+                return false;
+            } else if (logEntry.outputImages.length === 0) {
+                return false;
+            } else if (logEntry.outputImages.find((imgDescriptor) => {
+                if (!imgDescriptor) { return false; }
+                return imgDescriptor.repository === context.label;
+            })) {
+                return true
+            } else {
+                return false;
+            }
+        }
+    } else {
+        const tag: string = context.label.slice(context.label.search(':') + 1);
+        return (logEntry: Build) => {
+            if (!logEntry.outputImages) {
+                return false;
+            } else if (logEntry.outputImages.length === 0) {
+                return false;
+            } else if (logEntry.outputImages.find((imgDescriptor) => {
+                if (!imgDescriptor) { return false; }
+                return imgDescriptor.tag === tag;
+            })) {
+                return true
+            } else {
+                return false;
+            }
+        }
+    }
+}
+
+/** Class to manage data and data acquisition for logs */
+class LogData {
+    public registry: Registry;
+    public resourceGroup: string;
+    public links: { requesting: boolean, url?: string }[];
+    public logs: Build[];
+    public client: ContainerRegistryManagementClient;
+    private nextLink: string;
+
+    constructor(client: ContainerRegistryManagementClient, registry: Registry, resourceGroup: string) {
+        this.registry = registry;
+        this.resourceGroup = resourceGroup;
+        this.client = client;
+        this.logs = [];
+        this.links = [];
+    }
+    /** Acquires Links from an item number corresponding to the index of the corresponding log, caches
+     * logs in order to avoid unecessary requests if opened multiple times.
+     */
+    public async getLink(itemNumber: number): Promise<string> {
+        if (itemNumber >= this.links.length) {
+            throw new Error('Log for which the link was requested has not been added');
+        }
+
+        if (this.links[itemNumber].url) {
+            return this.links[itemNumber].url;
+        }
+
+        //If user is simply clicking many times impatiently it makes sense to only have one request at once
+        if (this.links[itemNumber].requesting) { return 'requesting' }
+
+        this.links[itemNumber].requesting = true;
+        const temp: BuildGetLogResult = await this.client.builds.getLogLink(this.resourceGroup, this.registry.name, this.logs[itemNumber].buildId);
+        this.links[itemNumber].url = temp.logLink;
+        this.links[itemNumber].requesting = false;
+        return this.links[itemNumber].url
+    }
+
+    public async loadMoreLogs(filterFunc?: (logEntry: Build) => boolean): Promise<void> {
+        let buildListResult: BuildListResult;
+        if (this.logs.length === 0) {
+            buildListResult = await this.client.builds.list(this.resourceGroup, this.registry.name);
+            this.nextLink = buildListResult.nextLink;
+        } else if (!this.nextLink) {
+            throw new Error('No more logs to show');
+        } else {
+            let options = { 'skipToken': this.nextLink };
+            buildListResult = await this.client.builds.list(this.resourceGroup, this.registry.name, options);
+            this.nextLink = buildListResult.nextLink;
+        }
+        if (filterFunc) {
+            buildListResult = buildListResult.filter(filterFunc);
+        }
+
+        this.addLogs(buildListResult);
+    }
+
+    public addLogs(logs: Build[]): void {
+        this.logs = this.logs.concat(logs);
+
+        const itemCount = logs.length;
+        for (let i = 0; i < itemCount; i++) {
+            this.links.push({ 'requesting': false });
+        }
+    }
+}

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -197,12 +197,12 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
         <div id = "header">
             <table id="headerTable">
                 <th class = 'arrowHolder'></td>
-                <th class = 'widthControl'>Build Name </th>
-                <th class = 'widthControl'>BuildTask </th>
-                <th class = 'widthControl'>Status </th>
-                <th class = 'widthControl'>Created </th>
-                <th class = 'widthControl'>Elapsed Time </th>
-                <th class = 'widthControl'>Platform </th>
+                <th class = 'widthControl'>Build Name<span class="sort">  </span></th>
+                <th class = 'widthControl'>BuildTask<span class="sort">  </span></th>
+                <th class = 'widthControl'>Status<span class="sort">  </span></th>
+                <th class = 'widthControl'>Created<span class="sort"> &#9661</span></th>
+                <th class = 'widthControl'>Elapsed Time<span class="sort">  </span></th>
+                <th class = 'widthControl'>Platform<span class="sort">  </span></th>
                 <td></td>
             </table>
         </div>

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -106,18 +106,22 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
                         </tr>
                         <tr class="panel">
                             <td colspan = "7">
-                                <div class= "paddingDiv">
+                                <div class= "paddingDiv overflowX">
                                     <table class="innerTable">
                                         <tr>
-                                            <td colspan="3">Output Images</td>
-                                            <td class = "lastTd" rowspan = "300">
-                                                <button id= "log${i}" class="viewLog">Open Logs</button>
+                                            <td class = "arrowHolder">&#160</td>
+                                            <td colspan = "5" class = "widthControl5">Output Images</td>
+                                            <td class = "widthControl lastTd" rowspan = "300">
+                                                <div class = "button-holder">
+                                                    <button id= "log${i}" class="viewLog">Open Logs</button>
+                                                </div>
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td>Tag</th>
-                                            <td>Repository</td>
-                                            <td>Digest</td>
+                                            <td class = "arrowHolder">&#160</td>
+                                            <td colspan = "2" class = 'widthControl2'>Tag</th>
+                                            <td colspan = "2" class = 'widthControl3'>Repository</td>
+                                            <td class = 'widthControl'>Digest</td>
                                         </tr>
                                         ${imageOutput}
                                     </table>
@@ -144,12 +148,13 @@ function getImageOutputTable(log: Build): string {
                 const repository: string = img.repository ? img.repository : '';
                 const digest: string = img.digest ? img.digest : '';
                 const truncatedDigest: string = digest ? digest.substr(0, 5) + '...' + digest.substr(digest.length - 5) : '';
-                const lastTr: string = j === log.outputImages.length - 1 ? 'class = "lastTr"' : '';
-                imageOutput += `<tr ${lastTr}>
-                                        <td>${tag}</td>
-                                        <td>${repository}</td>
-                                        <td data-digest = "${digest}">${truncatedDigest} <inline class = 'copy'>&#128459</inline></td>
-                                    </tr>`;
+                const lastTd: string = j === log.outputImages.length - 1 ? 'lastTd' : '';
+                imageOutput += `<tr>
+                                    <td class = "arrowHolder">&#160</td>
+                                    <td colspan = "2" class = "widthControl2 ${lastTd}">${tag}</td>
+                                    <td colspan = "2" class = "widthControl2 ${lastTd}">${repository}</td>
+                                    <td colspan = "1" class = "widthControl ${lastTd}" data-digest = "${digest}">${truncatedDigest} <inline class = 'copy'>&#128459</inline></td>
+                                </tr>`;
             }
         }
         if (!log.outputImages[0]) {
@@ -159,11 +164,12 @@ function getImageOutputTable(log: Build): string {
         needsNA = true;
     }
     if (needsNA) {
-        imageOutput += `<tr class = "lastTr">
-                                    <td>NA</td>
-                                    <td>NA</td>
-                                    <td>NA</td>
-                                </tr>`;
+        imageOutput += `<tr>
+                            <td class = "arrowHolder lastTd">&#160</td>
+                            <td colspan = "2" class = "widthControl2 lastTd">NA</td>
+                            <td colspan = "2" class = "widthControl2 lastTd">NA</td>
+                            <td colspan = "1" class = "widthControl lastTd">NA</td>
+                        </tr>`;
     }
     return imageOutput;
 }

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -100,39 +100,41 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
             'type': 'populate',
             'id': i,
             'logComponent': `
-                        <tr id= "btn${i}" class="accordion">
-                                <td class = 'arrowHolder'><div class = "arrow">&#x25f9</div></td>
-                                <td class = 'widthControl'>${name}</td>
-                                <td class = 'widthControl'>${buildTask}</td>
-                                <td class ='status widthControl ${log.status}'>${log.status}</td>
-                                <td class = 'widthControl'>${createTime}</td>
-                                <td class = 'widthControl'>${timeElapsed}</td>
-                                <td class = 'widthControl'>${osType}</td>
-                        </tr>
-                        <tr class="panel">
-                            <td colspan = "7">
-                                <div class= "paddingDiv overflowX">
-                                    <table class="innerTable">
-                                        <tr>
-                                            <td class = "arrowHolder">&#160</td>
-                                            <td colspan = "5" class = "borderLimit widthControl5">Output Images</td>
-                                            <td class = "widthControl lastTd" rowspan = "300">
-                                                <div class = "button-holder">
-                                                    <button id= "log${i}" class="viewLog">Open Logs</button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class = "arrowHolder">&#160</td>
-                                            <td colspan = "2" class = "borderLimit widthControl2">Tag</th>
-                                            <td colspan = "2" class = "widthControl3">Repository</td>
-                                            <td class = "widthControl">Digest</td>
-                                        </tr>
-                                        ${imageOutput}
-                                    </table>
-                                </div>
-                            </td>
-                        </tr>`
+                        <tbody class = "holder">
+                            <tr id= "btn${i}" class="accordion">
+                                    <td class = 'arrowHolder'><div class = "arrow">&#x25f9</div></td>
+                                    <td class = 'widthControl'>${name}</td>
+                                    <td class = 'widthControl'>${buildTask}</td>
+                                    <td class ='status widthControl ${log.status}'>${log.status}</td>
+                                    <td class = 'widthControl'>${createTime}</td>
+                                    <td class = 'widthControl'>${timeElapsed}</td>
+                                    <td class = 'widthControl'>${osType}</td>
+                            </tr>
+                            <tr class="panel">
+                                <td colspan = "7">
+                                    <div class= "paddingDiv overflowX">
+                                        <table class="innerTable">
+                                            <tr>
+                                                <td class = "arrowHolder">&#160</td>
+                                                <td colspan = "5" class = "borderLimit widthControl5">Output Images</td>
+                                                <td class = "widthControl lastTd" rowspan = "300">
+                                                    <div class = "button-holder">
+                                                        <button id= "log${i}" class="viewLog">Open Logs</button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td class = "arrowHolder">&#160</td>
+                                                <td colspan = "2" class = "borderLimit widthControl2">Tag</th>
+                                                <td colspan = "2" class = "widthControl3">Repository</td>
+                                                <td class = "widthControl">Digest</td>
+                                            </tr>
+                                            ${imageOutput}
+                                        </table>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>`
         });
     }
     if (startItem) {
@@ -204,10 +206,7 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
                 <td></td>
             </table>
         </div>
-            <table id = 'coreParent'>
-                <tbody id = 'core'>
-
-                </tbody>
+            <table id = 'core'>
             </table>
         <div class = 'loadMoreBtn'>
             <button id= "loadBtn" class="viewLog">Load More Logs</button>
@@ -220,8 +219,7 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
         </div>
 
         <script src= "${scriptFile}"></script>
-    </body>
-`;
+    </body>`;
 }
 /** Setup communication with the webview sorting out received mesages from its javascript file */
 function setupCommunication(panel: vscode.WebviewPanel, logData: LogData): void {

--- a/commands/azureCommands/acr-build-logs.ts
+++ b/commands/azureCommands/acr-build-logs.ts
@@ -86,7 +86,7 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
         const log = logData.logs[i];
         const buildTask: string = log.buildTask ? log.buildTask : '';
         const createTime: string = log.createTime ? log.createTime.toLocaleString() : '';
-        const timeElapsed: string = log.startTime && log.finishTime ? (Math.abs(log.startTime.valueOf() - log.finishTime.valueOf()) / 1000).toString() : '';
+        const timeElapsed: string = log.startTime && log.finishTime ? (Math.abs(log.startTime.valueOf() - log.finishTime.valueOf()) / 1000).toString() + 's' : '';
         const osType: string = log.platform.osType ? log.platform.osType : '';
         const name: string = log.name ? log.name : '';
         let imageOutput: string = getImageOutputTable(log);
@@ -99,13 +99,13 @@ function addLogsToWebView(panel: vscode.WebviewPanel, logData: LogData, startIte
                         <button id= "btn${i}" class="accordion">
                             <table>
                                 <tr>
+                                    <td class = 'arrowHolder'><div class = "arrow">&#x25f9</div></td>
                                     <td class = 'widthControl'>${name}</td>
                                     <td class = 'widthControl'>${buildTask}</td>
                                     <td class ='status widthControl ${log.status}'>${log.status}</td>
                                     <td class = 'widthControl'>${createTime}</td>
-                                    <td class = 'widthControl'>${timeElapsed}s</td>
+                                    <td class = 'widthControl'>${timeElapsed}</td>
                                     <td class = 'widthControl'>${osType}</td>
-                                    <td><div class = "arrow"></div></td>
                                 </tr>
                             </table>
                         </button>
@@ -187,6 +187,7 @@ function getWebviewContent(scriptFile: vscode.Uri, stylesheet: vscode.Uri): stri
     <body>
         <div id = "header">
             <table id="headerTable">
+                <th class = 'arrowHolder'></td>
                 <th class = 'widthControl'>Build Name </th>
                 <th class = 'widthControl'>BuildTask </th>
                 <th class = 'widthControl'>Status </th>

--- a/commands/azureCommands/acr-build.ts
+++ b/commands/azureCommands/acr-build.ts
@@ -1,12 +1,14 @@
 import { ContainerRegistryManagementClient } from 'azure-arm-containerregistry';
-import { QuickBuildRequest } from "azure-arm-containerregistry/lib/models";
-import { Registry } from 'azure-arm-containerregistry/lib/models';
+import { Build, Registry } from 'azure-arm-containerregistry/lib/models';
+import { BuildGetLogResult, QuickBuildRequest } from "azure-arm-containerregistry/lib/models";
 import { BlobService, createBlobServiceWithSas } from "azure-storage";
 import * as fs from 'fs';
 import * as os from 'os';
+import { Readable, Writable } from 'stream';
 import * as tar from 'tar';
 import * as url from 'url';
 import * as vscode from "vscode";
+import { ResourceGroup } from '../../node_modules/azure-arm-resource/lib/resource/models';
 import { getBlobInfo, getResourceGroupName } from "../../utils/Azure/acrTools";
 import { AzureUtilityManager } from "../../utils/azureUtilityManager";
 import { quickPickACRRegistry, quickPickResourceGroup, quickPickSubscription } from '../utils/quick-pick-azure';
@@ -37,7 +39,7 @@ export async function queueBuild(dockerFileUri?: vscode.Uri): Promise<void> {
         //Currently, there is no support for selecting source location folders that don't contain a path to the triggered dockerfile.
         throw new Error("Source code path must be a parent of the Dockerfile path");
     } else {
-        relativeDockerPath = dockerFileUri.path.toString().substring(sourceLocation.length);
+        relativeDockerPath = '.' + dockerFileUri.path.toString().substring(sourceLocation.length);
     }
 
     // Prompting for name so the image can then be pushed to a repository.
@@ -66,8 +68,9 @@ export async function queueBuild(dockerFileUri?: vscode.Uri): Promise<void> {
         'dockerFilePath': relativeDockerPath
     };
     status.appendLine("Queueing Build");
-    await client.registries.queueBuild(resourceGroupName, registry.name, buildRequest);
-    status.appendLine('Success');
+    const build: Build = await client.registries.queueBuild(resourceGroupName, registry.name, buildRequest);
+    status.show();
+    streamLogs2(client, resourceGroupName, registry, build);
 }
 
 async function uploadSourceCode(client: ContainerRegistryManagementClient, registryName: string, resourceGroupName: string, sourceLocation: string, tarFilePath: string): Promise<string> {
@@ -87,15 +90,10 @@ async function uploadSourceCode(client: ContainerRegistryManagementClient, regis
     status.appendLine("   Getting blob info from Upload Url ");
     // Right now, accountName and endpointSuffix are unused, but will be used for streaming logs later.
     let { accountName, endpointSuffix, containerName, blobName, sasToken, host } = getBlobInfo(upload_url);
-
     status.appendLine("   Creating Blob Service ");
     let blob: BlobService = createBlobServiceWithSas(host, sasToken);
-
     status.appendLine("   Creating Block Blob ");
-
     blob.createBlockBlobFromLocalFile(containerName, blobName, tarFilePath, (): void => { });
-
-    status.appendLine("   Success ");
     return relative_path;
 }
 
@@ -105,4 +103,52 @@ function getTempSourceArchivePath(): string {
     status.appendLine("Setting up temp file with 'sourceArchive" + id + ".tar.gz' ");
     let tarFilePath = url.resolve(os.tmpdir(), `sourceArchive${id}.tar.gz`);
     return tarFilePath;
+}
+
+async function streamLogs(client: ContainerRegistryManagementClient, resourceGroupName: string, registry: Registry, build: Build): Promise<void> {
+    const temp: BuildGetLogResult = await client.builds.getLogLink(resourceGroupName, registry.name, build.buildId);
+    const link = temp.logLink;
+    let blobInfo = getBlobInfo(link);
+    let blob: BlobService = createBlobServiceWithSas(blobInfo.host, blobInfo.sasToken);
+    let stream: Readable = new Readable();
+    try {
+        stream = blob.createReadStream(blobInfo.containerName, blobInfo.blobName, (error, response) => {
+            if (response) {
+                console.log(response.name + 'has Completed');
+            } else {
+                console.log(error);
+            }
+        });
+        console.log(stream);
+    } catch (error) {
+        console.log('a' + error);
+    }
+    stream.on('data', (chunk) => {
+        status.appendLine(chunk.toString());
+        status.show();
+    });
+
+}
+
+async function streamLogs2(client: ContainerRegistryManagementClient, resourceGroupName: string, registry: Registry, build: Build): Promise<void> {
+    const temp: BuildGetLogResult = await client.builds.getLogLink(resourceGroupName, registry.name, build.buildId);
+    const link = temp.logLink;
+    let blobInfo = getBlobInfo(link);
+    let blob: BlobService = createBlobServiceWithSas(blobInfo.host, blobInfo.sasToken);
+    let stream: Readable = new Readable();
+
+    stream = blob.createReadStream(blobInfo.containerName, blobInfo.blobName, (error, response) => {
+        if (response) {
+            status.appendLine(response.name + 'has Completed');
+        } else {
+            status.appendLine(error.message);
+        }
+        status.show();
+    });
+
+    stream.on('data', (chunk) => {
+        status.appendLine(chunk.toString());
+        status.show();
+    });
+
 }

--- a/commands/azureCommands/acr-build.ts
+++ b/commands/azureCommands/acr-build.ts
@@ -8,9 +8,9 @@ import * as os from 'os';
 import * as tar from 'tar';
 import * as url from 'url';
 import * as vscode from "vscode";
-import { getBlobInfo } from "../utils/Azure/acrTools";
-import { AzureUtilityManager } from "../utils/azureUtilityManager";
-import { quickPickACRRegistry, quickPickResourceGroup, quickPickSubscription } from './utils/quick-pick-azure';
+import { getBlobInfo } from "../../utils/Azure/acrTools";
+import { AzureUtilityManager } from "../../utils/azureUtilityManager";
+import { quickPickACRRegistry, quickPickResourceGroup, quickPickSubscription } from '../utils/quick-pick-azure';
 const idPrecision = 6;
 let status = vscode.window.createOutputChannel('status');
 

--- a/commands/azureCommands/delete-image.ts
+++ b/commands/azureCommands/delete-image.ts
@@ -2,7 +2,7 @@ import { Registry } from "azure-arm-containerregistry/lib/models";
 import * as vscode from "vscode";
 import { dockerExplorerProvider } from '../../dockerExtension';
 import { UserCancelledError } from "../../explorer/deploy/wizard";
-import { AzureImageNode, AzureRepositoryNode } from '../../explorer/models/AzureRegistryNodes';
+import { AzureImageNode, AzureRepositoryNode } from '../../explorer/models/azureRegistryNodes';
 import { reporter } from '../../telemetry/telemetry';
 import * as acrTools from '../../utils/Azure/acrTools';
 import { AzureImage } from "../../utils/Azure/models/image";

--- a/commands/azureCommands/delete-registry.ts
+++ b/commands/azureCommands/delete-registry.ts
@@ -3,7 +3,7 @@ import { SubscriptionModels } from "azure-arm-resource";
 import * as vscode from "vscode";
 import { dockerExplorerProvider } from '../../dockerExtension';
 import { UserCancelledError } from "../../explorer/deploy/wizard";
-import { AzureRegistryNode } from '../../explorer/models/AzureRegistryNodes';
+import { AzureRegistryNode } from '../../explorer/models/azureRegistryNodes';
 import { reporter } from '../../telemetry/telemetry';
 import * as acrTools from '../../utils/Azure/acrTools';
 import { AzureUtilityManager } from '../../utils/azureUtilityManager';

--- a/commands/azureCommands/delete-repository.ts
+++ b/commands/azureCommands/delete-repository.ts
@@ -3,7 +3,7 @@ import { Context } from "mocha";
 import * as vscode from "vscode";
 import { dockerExplorerProvider } from '../../dockerExtension';
 import { UserCancelledError } from "../../explorer/deploy/wizard";
-import { AzureRegistryNode, AzureRepositoryNode } from '../../explorer/models/AzureRegistryNodes';
+import { AzureRegistryNode, AzureRepositoryNode } from '../../explorer/models/azureRegistryNodes';
 import { reporter } from '../../telemetry/telemetry';
 import * as acrTools from '../../utils/Azure/acrTools';
 import { Repository } from "../../utils/Azure/models/repository";

--- a/commands/azureCommands/delete-repository.ts
+++ b/commands/azureCommands/delete-repository.ts
@@ -32,7 +32,7 @@ export async function deleteRepository(context?: AzureRepositoryNode): Promise<v
         const { acrAccessToken } = await acrTools.acquireACRAccessTokenFromRegistry(registry, `repository:${repoName}:*`);
         const path = `/v2/_acr/${repoName}/repository`;
         await acrTools.sendRequestToRegistry('delete', registry.loginServer, path, acrAccessToken);
-        vscode.window.showInformationMessage(`Successfully deleted repository ${Repository}`);
+        vscode.window.showInformationMessage(`Successfully deleted repository ${repoName}`);
         if (context) {
             dockerExplorerProvider.refreshNode(context.parent);
         }

--- a/commands/azureCommands/pull-from-azure.ts
+++ b/commands/azureCommands/pull-from-azure.ts
@@ -1,7 +1,7 @@
 import vscode = require('vscode');
 import { reporter } from '../../telemetry/telemetry';
 const teleCmdId: string = 'vscode-docker.image.pullFromAzure';
-import { AzureImageNode } from '../../explorer/models/AzureRegistryNodes';
+import { AzureImageNode } from '../../explorer/models/azureRegistryNodes';
 import * as acrTools from '../../utils/Azure/acrTools';
 
 /* Pulls an image from Azure. The context is the image node the user has right clicked on */

--- a/commands/azureCommands/pull-from-azure.ts
+++ b/commands/azureCommands/pull-from-azure.ts
@@ -1,10 +1,10 @@
 import vscode = require('vscode');
 import { reporter } from '../../telemetry/telemetry';
 const teleCmdId: string = 'vscode-docker.image.pullFromAzure';
+//tslint ignore-next-line
+import { exec } from 'child_process';
 import { AzureImageNode } from '../../explorer/models/azureRegistryNodes';
 import * as acrTools from '../../utils/Azure/acrTools';
-//tslint ignore-next-line
-const { exec } = require('child_process');
 
 /* Pulls an image from Azure. The context is the image node the user has right clicked on */
 export async function pullFromAzure(context?: AzureImageNode): Promise<any> {

--- a/commands/utils/quick-pick-azure.ts
+++ b/commands/utils/quick-pick-azure.ts
@@ -116,7 +116,7 @@ export async function quickPickResourceGroup(canCreateNew?: boolean, subscriptio
     let resourceGroups = await AzureUtilityManager.getInstance().getResourceGroups(subscription);
     let resourceGroupNames: string[] = [];
 
-    if (canCreateNew) { resourceGroupNames.push('+ Create new resource group'); }
+    if (canCreateNew) { resourceGroupNames.push('+ Create new Resource Group'); }
     for (let resGroupName of resourceGroups) {
         resourceGroupNames.push(resGroupName.name);
     }

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -6,8 +6,10 @@ import * as opn from 'opn';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureUserInput, createTelemetryReporter, registerCommand, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
-import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/lib/main';
 import { queueBuild } from './commands/acr-build';
+import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { viewBuildLogs } from './commands/azureCommands/acr-build-logs'
+import { LogContentProvider } from './commands/azureCommands/acr-build-logs-utils/logProvider';
 import { createRegistry } from './commands/azureCommands/create-registry';
 import { deleteAzureImage } from './commands/azureCommands/delete-image';
 import { deleteAzureRegistry } from './commands/azureCommands/delete-registry';
@@ -168,13 +170,19 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
     ctx.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('docker', new DockerDebugConfigProvider()));
 
+    //If ms-vscode.azure-account extension is present
     if (azureAccount) {
         registerCommand('vscode-docker.delete-ACR-Registry', deleteAzureRegistry);
         registerCommand('vscode-docker.delete-ACR-Image', deleteAzureImage);
         registerCommand('vscode-docker.delete-ACR-Repository', deleteRepository);
         registerCommand('vscode-docker.create-ACR-Registry', createRegistry);
+        registerCommand('vscode-docker.acrBuildLogs', viewBuildLogs);
         AzureUtilityManager.getInstance().setAccount(azureAccount);
 
+        // instantiate LogProvider
+        const logProvider = new LogContentProvider();
+        const registration = vscode.workspace.registerTextDocumentContentProvider(LogContentProvider.scheme, logProvider);
+        ctx.subscriptions.push(registration);
     }
 
     activateLanguageClient(ctx);

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -6,8 +6,8 @@ import * as opn from 'opn';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureUserInput, createTelemetryReporter, registerCommand, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
-import { queueBuild } from './commands/acr-build';
-import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/lib/main';
+import { queueBuild } from './commands/azureCommands/acr-build';
 import { viewBuildLogs } from './commands/azureCommands/acr-build-logs'
 import { LogContentProvider } from './commands/azureCommands/acr-build-logs-utils/logProvider';
 import { createRegistry } from './commands/azureCommands/create-registry';
@@ -123,7 +123,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     registerCommand('vscode-docker.image.remove', removeImage);
     registerCommand('vscode-docker.image.push', pushImage);
     registerCommand('vscode-docker.image.tag', tagImage);
-    registerCommand('vscode-docker.queueBuild', queueBuild);
     registerCommand('vscode-docker.container.start', startContainer);
     registerCommand('vscode-docker.container.start.interactive', startContainerInteractive);
     registerCommand('vscode-docker.container.start.azurecli', startAzureCLI);
@@ -177,6 +176,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         registerCommand('vscode-docker.delete-ACR-Repository', deleteRepository);
         registerCommand('vscode-docker.create-ACR-Registry', createRegistry);
         registerCommand('vscode-docker.acrBuildLogs', viewBuildLogs);
+        registerCommand('vscode-docker.queueBuild', queueBuild);
         AzureUtilityManager.getInstance().setAccount(azureAccount);
 
         // instantiate LogProvider

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureUserInput, createTelemetryReporter, registerCommand, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
 import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/lib/main';
+import { queueBuild } from './commands/acr-build';
 import { createRegistry } from './commands/azureCommands/create-registry';
 import { deleteAzureImage } from './commands/azureCommands/delete-image';
 import { deleteAzureRegistry } from './commands/azureCommands/delete-registry';
@@ -120,6 +121,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     registerCommand('vscode-docker.image.remove', removeImage);
     registerCommand('vscode-docker.image.push', pushImage);
     registerCommand('vscode-docker.image.tag', tagImage);
+    registerCommand('vscode-docker.queueBuild', queueBuild);
     registerCommand('vscode-docker.container.start', startContainer);
     registerCommand('vscode-docker.container.start.interactive', startContainerInteractive);
     registerCommand('vscode-docker.container.start.azurecli', startAzureCLI);
@@ -134,7 +136,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     registerCommand('vscode-docker.system.prune', systemPrune);
     registerCommand('vscode-docker.deleteAzureImage', deleteAzureImage);
     registerCommand('vscode-docker.pullFromAzure', pullFromAzure);
-
     registerCommand('vscode-docker.createWebApp', async (context?: AzureImageNode | DockerHubImageNode) => {
         if (context) {
             if (azureAccount) {
@@ -173,6 +174,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         registerCommand('vscode-docker.delete-ACR-Repository', deleteRepository);
         registerCommand('vscode-docker.create-ACR-Registry', createRegistry);
         AzureUtilityManager.getInstance().setAccount(azureAccount);
+
     }
 
     activateLanguageClient(ctx);

--- a/explorer/models/azureRegistryNodes.ts
+++ b/explorer/models/azureRegistryNodes.ts
@@ -208,7 +208,7 @@ export class AzureRepositoryNode extends NodeBase {
                 pool.addTask(async () => {
                     let data: string;
                     try {
-                        data = await request.get('https://' + element.repository + '/v2/' + element.label + `/manifests/${tags}`, {
+                        data = await request.get('https://' + element.repository + '/v2/' + element.label + `/manifests/${tag}`, {
                             auth: {
                                 bearer: accessTokenARC
                             }

--- a/explorer/models/taskNode.ts
+++ b/explorer/models/taskNode.ts
@@ -38,7 +38,6 @@ export class TaskRootNode extends NodeBase {
 
         const client = AzureUtilityManager.getInstance().getContainerRegistryManagementClient(element.subscription);
         const resourceGroup: string = acrTools.getResourceGroupName(element.registry);
-
         buildTasks = await client.buildTasks.list(resourceGroup, element.registry.name);
         if (buildTasks.length === 0) {
             vscode.window.showInformationMessage(`You do not have any Build Tasks in the registry, '${element.registry.name}'. You can create one with ACR Build. `, "Learn More").then(val => {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
   "main": "./out/dockerExtension",
   "contributes": {
     "menus": {
-      "commandPalette": [
-        {
+      "commandPalette": [{
           "command": "vscode-docker.browseDockerHub",
           "when": "false"
         },
@@ -74,8 +73,7 @@
           "when": "false"
         }
       ],
-      "editor/context": [
-        {
+      "editor/context": [{
           "when": "editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
           "group": "docker"
@@ -116,8 +114,7 @@
           "group": "docker"
         }
       ],
-      "explorer/context": [
-        {
+      "explorer/context": [{
           "when": "resourceFilename =~ /[dD]ocker[fF]ile/",
           "command": "vscode-docker.image.build",
           "group": "docker"
@@ -143,8 +140,7 @@
           "group": "docker"
         }
       ],
-      "view/title": [
-        {
+      "view/title": [{
           "command": "vscode-docker.explorer.refresh",
           "when": "view == dockerExplorer",
           "group": "navigation"
@@ -155,8 +151,7 @@
           "group": "navigation"
         }
       ],
-      "view/item/context": [
-        {
+      "view/item/context": [{
           "command": "vscode-docker.container.start",
           "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/"
         },
@@ -249,45 +244,43 @@
           "when": "view == dockerExplorer && viewItem == azureRepositoryNode"
         },
         {
+          "command": "vscode-docker.delete-ACR-Repository",
+          "when": "view == dockerExplorer && viewItem == azureRepositoryNode"
+        },
+        {
           "command": "vscode-docker.acrBuildLogs",
           "when": "view == dockerExplorer && viewItem == azureImageNode"
         }
       ]
     },
-    "debuggers": [
-      {
-        "type": "docker",
-        "label": "Docker",
-        "configurationSnippets": [
-          {
-            "label": "Docker: Attach to Node",
-            "description": "Docker: Attach to Node",
-            "body": {
-              "type": "node",
-              "request": "attach",
-              "name": "Docker: Attach to Node",
-              "port": 9229,
-              "address": "localhost",
-              "localRoot": "^\"\\${workspaceFolder}\"",
-              "remoteRoot": "/usr/src/app",
-              "protocol": "inspector"
-            }
-          }
-        ]
-      }
-    ],
-    "languages": [
-      {
-        "id": "dockerfile",
-        "aliases": [
-          "Dockerfile"
-        ],
-        "filenamePatterns": [
-          "*.dockerfile",
-          "Dockerfile"
-        ]
-      }
-    ],
+    "debuggers": [{
+      "type": "docker",
+      "label": "Docker",
+      "configurationSnippets": [{
+        "label": "Docker: Attach to Node",
+        "description": "Docker: Attach to Node",
+        "body": {
+          "type": "node",
+          "request": "attach",
+          "name": "Docker: Attach to Node",
+          "port": 9229,
+          "address": "localhost",
+          "localRoot": "^\"\\${workspaceFolder}\"",
+          "remoteRoot": "/usr/src/app",
+          "protocol": "inspector"
+        }
+      }]
+    }],
+    "languages": [{
+      "id": "dockerfile",
+      "aliases": [
+        "Dockerfile"
+      ],
+      "filenamePatterns": [
+        "*.dockerfile",
+        "Dockerfile"
+      ]
+    }],
     "configuration": {
       "type": "object",
       "title": "Docker configuration options",
@@ -447,8 +440,7 @@
         }
       }
     },
-    "commands": [
-      {
+    "commands": [{
         "command": "vscode-docker.configure",
         "title": "Add Docker files to Workspace",
         "description": "Add Dockerfile, docker-compose.yml files",
@@ -630,22 +622,18 @@
       }
     ],
     "views": {
-      "dockerView": [
-        {
-          "id": "dockerExplorer",
-          "name": "Explorer",
-          "when": "config.docker.showExplorer == true"
-        }
-      ]
+      "dockerView": [{
+        "id": "dockerExplorer",
+        "name": "Explorer",
+        "when": "config.docker.showExplorer == true"
+      }]
     },
     "viewsContainers": {
-      "activitybar": [
-        {
-          "icon": "images/docker.svg",
-          "id": "dockerView",
-          "title": "Docker"
-        }
-      ]
+      "activitybar": [{
+        "icon": "images/docker.svg",
+        "id": "dockerView",
+        "title": "Docker"
+      }]
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "activationEvents": [
     "onLanguage:dockerfile",
     "onLanguage:yaml",
+    "onCommand:vscode-docker.acrBuildLogs",
     "onCommand:vscode-docker.image.build",
     "onCommand:vscode-docker.image.inspect",
     "onCommand:vscode-docker.image.remove",
@@ -238,6 +239,18 @@
         {
           "command": "vscode-docker.browseAzurePortal",
           "when": "view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureRepositoryNode|azureImageNode)$/"
+        },
+        {
+          "command": "vscode-docker.acrBuildLogs",
+          "when": "view == dockerExplorer && viewItem == azureRegistryNode"
+        },
+        {
+          "command": "vscode-docker.acrBuildLogs",
+          "when": "view == dockerExplorer && viewItem == azureRepositoryNode"
+        },
+        {
+          "command": "vscode-docker.acrBuildLogs",
+          "when": "view == dockerExplorer && viewItem == azureImageNode"
         }
       ]
     },
@@ -609,6 +622,11 @@
         "command": "vscode-docker.queueBuild",
         "title": "Lightweight Build",
         "category": "Docker"
+      },
+      {
+        "command": "vscode-docker.acrBuildLogs",
+        "title": "ACR build logs",
+        "category": "Docker"
       }
     ],
     "views": {
@@ -666,7 +684,7 @@
     "vscode": "^1.1.18"
   },
   "dependencies": {
-    "azure-arm-containerregistry": "^2.3.0",
+    "azure-arm-containerregistry": "^2.4.0",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
     "dockerfile-language-server-nodejs": "^0.0.18",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "onCommand:vscode-docker.create-ACR-Registry",
     "onCommand:vscode-docker.system.prune",
     "onCommand:vscode-docker.dockerHubLogout",
+    "onCommand:vscode-docker.queuebuild",
     "onCommand:vscode-docker.browseDockerHub",
     "onCommand:vscode-docker.browseAzurePortal",
     "onCommand:vscode-docker.explorer.refresh",
@@ -76,6 +77,11 @@
         {
           "when": "editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
+          "group": "docker"
+        },
+        {
+          "when": "editorLangId == dockerfile",
+          "command": "vscode-docker.queueBuild",
           "group": "docker"
         },
         {
@@ -113,6 +119,11 @@
         {
           "when": "resourceFilename =~ /[dD]ocker[fF]ile/",
           "command": "vscode-docker.image.build",
+          "group": "docker"
+        },
+        {
+          "when": "resourceFilename =~ /[dD]ocker[fF]ile/",
+          "command": "vscode-docker.queueBuild",
           "group": "docker"
         },
         {
@@ -593,6 +604,11 @@
         "command": "vscode-docker.delete-ACR-Image",
         "title": "Delete Azure Image",
         "category": "Docker"
+      },
+      {
+        "command": "vscode-docker.queueBuild",
+        "title": "Lightweight Build",
+        "category": "Docker"
       }
     ],
     "views": {
@@ -662,6 +678,7 @@
     "opn": "^5.1.0",
     "pom-parser": "^1.1.1",
     "request-promise": "^4.2.2",
+    "tar": "^4.4.6",
     "vscode-azureextensionui": "^0.16.6",
     "vscode-extension-telemetry": "0.0.18",
     "vscode-languageclient": "^4.4.0"

--- a/utils/Azure/acrTools.ts
+++ b/utils/Azure/acrTools.ts
@@ -108,6 +108,7 @@ export async function loginCredentials(registry: Registry): Promise<{ password: 
         return { 'password': acrRefreshToken, 'username': NULL_GUID };
     }
 }
+
 /** Obtains tokens for using the Docker Registry v2 Api
  * @param registry The targeted Azure Container Registry
  * @param scope String determining the scope of the access token

--- a/utils/Azure/acrTools.ts
+++ b/utils/Azure/acrTools.ts
@@ -157,3 +157,14 @@ export async function acquireACRAccessToken(registryUrl: string, scope: string, 
     });
     return JSON.parse(acrAccessTokenResponse).access_token;
 }
+
+export function getBlobInfo(blobUrl: string): { accountName: string, endpointSuffix: string, containerName: string, blobName: string, sasToken: string, host: string } {
+    let items: string[] = blobUrl.slice(blobUrl.search('https://') + 'https://'.length).split('/');
+    let accountName: string = blobUrl.slice(blobUrl.search('https://') + 'https://'.length, blobUrl.search('.blob'));
+    let endpointSuffix: string = items[0].slice(items[0].search('.blob.') + '.blob.'.length);
+    let containerName: string = items[1];
+    let blobName: string = items[2] + '/' + items[3] + '/' + items[4].slice(0, items[4].search('[?]'));
+    let sasToken: string = items[4].slice(items[4].search('[?]') + 1);
+    let host: string = accountName + '.blob.' + endpointSuffix;
+    return { accountName, endpointSuffix, containerName, blobName, sasToken, host };
+}

--- a/utils/Azure/models/repository.ts
+++ b/utils/Azure/models/repository.ts
@@ -4,19 +4,19 @@ import * as acrTools from '../acrTools';
 
 /** Class Azure Repository: Used locally, Organizes data for managing Repositories */
 export class Repository {
-    public registry: Registry;
-    public name: string;
-    public subscription: SubscriptionModels.Subscription;
-    public resourceGroupName: string;
-    public password?: string;
-    public username?: string;
+        public registry: Registry;
+        public name: string;
+        public subscription: SubscriptionModels.Subscription;
+        public resourceGroupName: string;
+        public password?: string;
+        public username?: string;
 
-    constructor(registry: Registry, repository: string, password?: string, username?: string) {
-        this.registry = registry;
-        this.resourceGroupName = acrTools.getResourceGroupName(registry);
-        this.subscription = acrTools.getSubscriptionFromRegistry(registry);
-        this.name = repository;
-        if (password) { this.password = password; }
-        if (username) { this.username = username; }
-    }
+        constructor(registry: Registry, repository: string, password?: string, username?: string) {
+                this.registry = registry;
+                this.resourceGroupName = acrTools.getResourceGroupName(registry);
+                this.subscription = acrTools.getSubscriptionFromRegistry(registry);
+                this.name = repository;
+                if (password) { this.password = password; }
+                if (username) { this.username = username; }
+        }
 }


### PR DESCRIPTION
This PR replaces #41 (Note PR 41 is not closed as all items  have not been addressed, this PR exists due to the long process for rebasing of the previous)

Opened issue #48 to track UI improvements, please note those there

This PR will close #9, #38 , and #44  
Working on: #8, #45, #48

Rather large PR containing all that has been done for ACR build log visualization. Would appreciate any feedback. 

Added ACR build log support
- 4 ways to activate
   - Right click on Registry
    - Right click on Repository
    - Right click on tag
    - ctrl +p => select registry from dropdown

Opens a webview that is sorted based on the location selected (e.g. if right click on a repository it will only show builds that generated images in that repository).

WebView features:
- View logs
- Build Name, Build Task, Status, start time, Finish Time, Platform
- Animated Dropdown on click
     - Output Images
     - Open Logs
- Sort Logs by any of name, task, status, start time, finish time and platform
- Theme adaptable, adapts to different visual studio themes

LogView features:
- Visualize a log in a separate window
- Simples but helpful coloring of errors and successes